### PR TITLE
Rename package name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run:
           name: Check latest heroku-cli
           command: |
-            npm info heroku-cli versions --json | jq --raw-output .[-1:][0] > VERSION
+            npm info heroku versions --json | jq --raw-output .[-1:][0] > VERSION
 
       - run:
           name: Update VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER sue445 <sue445@sue445.net>
 
 RUN apk --update --no-cache add bash git openssh-client
 
-RUN npm install -g heroku-cli \
+RUN npm install -g heroku \
  && rm -rf /tmp/* /root/.npm \
  && cd /usr/local/lib/node_modules/npm/ \
  && rm -rf man doc html *.md *.bat *.yml changelogs scripts test AUTHORS LICENSE Makefile \


### PR DESCRIPTION
```
npm WARN deprecated heroku-cli@7.0.9: 'heroku-cli' has been renamed 'heroku'
```