### PR TITLE
Fix deprecation warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:10-alpine
 
 RUN apk --update --no-cache add bash git openssh-client
 


### PR DESCRIPTION
```
npm WARN notsup Unsupported engine for globby@11.0.2: wanted: {"node":">=10"} (current: {"node":"8.17.0","npm":"6.13.4"})
```

c.f. https://github.com/sue445/dockerfile-heroku-cli/runs/1844339784?check_suite_focus=true