### PR TITLE
Upgrade to node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:14-alpine
 
 RUN apk --update --no-cache add bash git openssh-client
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:12-alpine
 
 RUN apk --update --no-cache add bash git openssh-client
 


### PR DESCRIPTION
* `heroku/cli` requires node 12+
  * https://github.com/heroku/cli/blob/v8.0.0/package.json#L23
* `@oclif/core` requires node 14+
  * https://github.com/oclif/core/blob/v1.16.4/package.json#L81
  * 26d2fda11abe9ec3a0d8e9c1e37e96a76f60ddc6

Close #35