### PR TITLE
Fix error in `docker-compose.test.yml`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-alpine
 
-RUN apk --update --no-cache add bash git openssh-client
+RUN apk --update --no-cache add bash git openssh-client coreutils
 
 ENV HEROKU_CLI_VERSION 11.1.1
 


### PR DESCRIPTION
```
Run docker compose --file docker-compose.test.yml run sut
 Network dockerfile-heroku-cli_default  Creating
 Network dockerfile-heroku-cli_default  Created
/usr/bin/env: unrecognized option: S
BusyBox v1.37.0 (2025-12-16 14:19:28 UTC) multi-call binary.

Usage: env [-i0] [-u NAME]... [-] [NAME=VALUE]... [PROG ARGS]

Print current environment or run PROG after setting up environment

	-, -i	Start with empty environment
	-0	NUL terminated output
	-u NAME	Remove variable from environment
```